### PR TITLE
fix(fabric): Update configmap from tessera node chart

### DIFF
--- a/platforms/hyperledger-besu/charts/besu-tessera-node/templates/configmap.yaml
+++ b/platforms/hyperledger-besu/charts/besu-tessera-node/templates/configmap.yaml
@@ -24,7 +24,7 @@ data:
       "useWhiteList": "false",
       "jdbc": {
         "username": {{ .Values.tessera.dbUsername | quote }},
-        "password": "",
+        "password": {{ .Values.tessera.password | quote }},
         "url": "jdbc:mysql://{{ include "besu-tessera-node.fullname" . }}:{{ .Values.tessera.dbport }}/demodb"
       },
       "serverConfigs": [


### PR DESCRIPTION
Password field to connect to mysql was empty, and it is needed the password for the user that was set on the mysql init container.

Tessera is up and running after the fix.

![Screenshot 2024-10-23 at 23 16 32](https://github.com/user-attachments/assets/b05d0747-c1d9-4176-8f20-527c32da366a)
