### PR TITLE
The orderer chart requires bevel-vault-script on minikube deploy

### DIFF
--- a/platforms/shared/charts/bevel-scripts/templates/configmap.yaml
+++ b/platforms/shared/charts/bevel-scripts/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
 {{ (.Files.Glob "scripts/aws-secret-manager-script.py").AsConfig | indent 2 }}
 {{- end }}
 {{- else }}
-{{- if eq .Values.global.vault.type "hashicorp" }}
+{{- if has .Values.global.vault.type (list "hashicorp" "kubernetes") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Related to issue: https://github.com/hyperledger-bevel/bevel/issues/2653

The problem: the orderer pod always tries to mount bevel-vault-script configmap, but such resource is not created for a minikube deploy.

In this PR, the configmap is always created to be mounted.